### PR TITLE
fix(assume.ml): Add missing case for (&&)

### DIFF
--- a/easy-check/src/assume/assume.ml
+++ b/easy-check/src/assume/assume.ml
@@ -273,6 +273,7 @@ module Tail_rec = struct
     | Pexp_apply (e,es) -> 
       (let tail' = match e with 
                   | {pexp_desc=Pexp_ident {txt=Lident "||"}} -> tail
+                  | {pexp_desc=Pexp_ident {txt=Lident "&&"}} -> tail
                   | _ -> false 
        in
        try 


### PR DESCRIPTION
Hi @lsylvestre !

It happens I recently used easy-check to benefit from its `tailrec` primitive :)

And noticed there was a missing case for the `(&&)` operator.

Otherwise, for example,
```
let rec forall2 p l1 l2 =
  match l1, l2 with
  | [], [] -> true
  | x1 :: l1, x2 :: l2 -> p x1 x2 && forall2 p l1 l2
  | _ -> false
```
is not seen as tail-recursive, while it is.

Happy new year!
Best regards,
Erik