### PR TITLE
fix: Avoid Match__failure assume.ml:331:18 (if we "inline" test in the code)

### DIFF
--- a/easy-check/src/assume/assume.ml
+++ b/easy-check/src/assume/assume.ml
@@ -334,6 +334,7 @@ module Tail_rec = struct
         let idents = idents_of_value_bindings bds in
         if List.mem name idents then (recflag,bds) 
         else aux r
+    | _ :: r -> aux r
     in aux code_ast
     
   (* [globals name] rend la liste des identificateurs déclarés dans


### PR DESCRIPTION
Hi @lsylvestre !

In our latest OCaml assignement (where easy-check is part of our test.ml code), we noticed that if students do "inline tests", i.e., if they write:

```ocaml
let f x sth = "..." ;;

f 2 3;;
```

then the learn-ocaml grader crashes with `Match__failure assume.ml:331:18`

However, if the students rather write:

```ocaml
let f x sth = "..." 

let test1 = f 2 3
```

then the issue does not show up.

Of course, the first phrasing is not idiomatic (as the "expression test" does not do any side-effect), but I believe it's better to fix this…

Hence this PR suggestion !-)